### PR TITLE
Restrict allowed chars in gitlab_database_password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,7 +148,7 @@ gitlab_database_password_path: "{{ secret + '/' + gitlab_database + '/' +
 # .. envvar:: gitlab_database_password
 #
 # Database password for GitLab.
-gitlab_database_password: "{{ lookup('password', gitlab_database_password_path + ' length=48') }}"
+gitlab_database_password: "{{ lookup('password', gitlab_database_password_path + ' length=48 chars=ascii_letters,digits,.:-_') }}"
 
 # .. envvar:: gitlab_postgresql_database_connection
 #


### PR DESCRIPTION
fixes #36