### PR TITLE
set deny_hidden to false in nginx config

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -131,6 +131,8 @@ gitlab_nginx_server:
   name: '{{ gitlab_domain }}'
   root: '{{ gitlab_ce_git_checkout }}/public'
 
+  deny_hidden: False
+
   access_policy: '{{ gitlab_nginx_access_policy }}'
   auth_basic_realm: '{{ gitlab_nginx_auth_realm }}'
 


### PR DESCRIPTION
this allows visiting files in a repository that start with a dot (e.g. .gitignore)