### PR TITLE
Always have at least two Unicorn worker processes.

### DIFF
--- a/templates/var/local/git/gitlab/config/unicorn.rb.j2
+++ b/templates/var/local/git/gitlab/config/unicorn.rb.j2
@@ -18,11 +18,8 @@
 # Read about unicorn workers here:
 # http://doc.gitlab.com/ee/install/requirements.html#unicorn-workers
 #
-{% if (ansible_local|d() and ansible_local.nginx|d() and ansible_local.nginx.flavor == 'passenger') %}
-worker_processes 1
-{% else %}
-worker_processes {{ ansible_processor_cores }}
-{% endif %}
+# Always have at least two worker processes (https://gitlab.com/gitlab-org/gitlab-ce/issues/13947)
+worker_processes {{ ansible_processor_cores|int + 1 }}
 
 # Since Unicorn is never exposed to outside clients, it does not need to
 # run on the standard HTTP port (80), there is no reason to start Unicorn


### PR DESCRIPTION
Having just one Unicorn worker process breaks certain features,
like deleting branches and committing from the web UI.

(See https://gitlab.com/gitlab-org/gitlab-ce/issues/13947)