### PR TITLE
Quotes for email_display_name setting.

### DIFF
--- a/templates/var/local/git/gitlab/config/gitlab.yml.j2
+++ b/templates/var/local/git/gitlab/config/gitlab.yml.j2
@@ -50,7 +50,7 @@ production: &base
     # email_enabled: true
     # Email address used in the "From" field in mails sent by GitLab
     email_from: {{ gitlab_email_from | default('gitlab@localhost') }}
-    email_display_name: {{ gitlab_email_display_name | default('GitLab') }}
+    email_display_name: '{{ gitlab_email_display_name | default('GitLab') }}'
     email_reply_to: {{ gitlab_email_reply_to | default('noreply@example.com') }}
 
     # Email server smtp settings are in config/initializers/smtp_settings.rb.sample


### PR DESCRIPTION
Quotes needed If `gitlab_email_display_name` contains spaces.