### PR TITLE
Update to gitlab version 8.12.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ gitlab_dependencies: True
 # .. envvar:: gitlab_version
 #
 # What version of GitLab to install / manage
-gitlab_version: '8.11'
+gitlab_version: '8.12'
 
 
 # ---------------------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,12 +4,10 @@ dependencies:
   - role: debops.apt_preferences
     tags: [ 'depend::apt_preferences', 'type::dependency', 'depend-of::gitlab', 'type::dependency' ]
     apt_preferences_dependent_list:
-      - package: 'golang golang-*'
-        backports: [ 'wheezy' ]
-        reason: 'Version parity with Debian Jessie'
-        by_role: 'debops.gitlab'
-
       - '{{ ruby__apt_preferences__dependent_list }}'
+
+  - role: debops.golang
+    tags: [ 'depend::golang', 'depend::golang:gitlab', 'depend-of::gitlab', 'type::dependency:hard' ]
 
   - role: debops.secret
     tags: [ 'depend::secret', 'depend::secret:gitlab', 'depend-of::gitlab', 'type::dependency:hard' ]

--- a/tasks/configure_gitlab-workhorse.yml
+++ b/tasks/configure_gitlab-workhorse.yml
@@ -77,12 +77,6 @@
   register: gitlab_register_gitlab_workhorse_checkout
   when: (gitlab_version_map[gitlab_version].gitlab_workhorse != gitlab_register_gitlab_workhorse_target_tag.stdout) or not gitlab_register_gitlab_workhorse_cloned.stat.exists
 
-- name: Install go packages
-  apt:
-    name: 'golang-go'
-    state: 'latest'
-    install_recommends: False
-
 - name: Setup gitlab-workhorse
   shell: make chdir={{ gitlab_workhorse_checkout }}
   become_user: '{{ gitlab_user }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -129,6 +129,11 @@ gitlab_version_map:
     ce:    '8-11-stable'
     gitlab_workhorse: 'v0.7.11'
 
+  '8.12':
+    shell: 'v3.6.3'
+    ce:    '8-12-stable'
+    gitlab_workhorse: 'v0.8.5'
+
 # ---- GitLab CE installation ----
 
 # List of packages required by GitLab


### PR DESCRIPTION
gitlab-workhorse v0.8.5 requires go 1.6 to compile vendorized
libraries. The debops.golang will take care of this for us.