### PR TITLE
add PATH environment for gitlab-workhorse service

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changed
 ~~~~~~~
 
 - Role documentation improvements. [ypid_]
+- add PATH environment for gitlab-workhorse service for artifact uploads [cultcom]
 
 
 `debops.gitlab v0.2.0`_ - 2017-04-06

--- a/templates/etc/systemd/system/gitlab-workhorse.service.j2
+++ b/templates/etc/systemd/system/gitlab-workhorse.service.j2
@@ -23,6 +23,7 @@ User={{ gitlab_user }}
 WorkingDirectory={{ gitlab_app_root_path }}/gitlab-workhorse
 SyslogIdentifier=gitlab-workhorse
 PIDFile={{ gitlab_app_root_path }}/gitlab/tmp/pids/gitlab-workhorse.pid
+Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:{{ gitlab_app_root_path }}/gitlab-workhorse"
 
 ExecStart={{ gitlab_app_root_path }}/gitlab/bin/daemon_with_pidfile {{ gitlab_app_root_path }}/gitlab/tmp/pids/gitlab-workhorse.pid {{ gitlab_app_root_path }}/gitlab-workhorse/gitlab-workhorse -listenUmask 0 -listenNetwork unix -listenAddr {{ gitlab_app_root_path }}/gitlab/tmp/sockets/gitlab-workhorse.socket -authBackend http://127.0.0.1:8080 -authSocket {{ gitlab_app_root_path }}/gitlab/tmp/sockets/gitlab.socket -secretPath {{ gitlab_app_root_path }}/gitlab/.gitlab_workhorse_secret -documentRoot {{ gitlab_app_root_path }}/gitlab/public >> {{ gitlab_app_root_path }}/gitlab/log/gitlab-workhorse.log 2>&1
 


### PR DESCRIPTION
for artifact uploads by gitlab-runner instances the workhorse service
tries to run "gitlab-zip-cat" and "gitlab-zip-metadata" which have to be
in the PATH.
Otherwise it results in "Internal Server Errros" in the job log.